### PR TITLE
fix: auto-complete untuk semua mode & auto-focus saat masuk test

### DIFF
--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -50,13 +50,17 @@ export default function TestPage() {
   // Focus management
   useEffect(() => {
     setFocusMode(true);
-    if (containerRef.current) {
-      containerRef.current.focus();
-    }
     return () => {
       setFocusMode(false);
     };
   }, [setFocusMode]);
+
+  // Auto-focus saat status running (setelah loading selesai)
+  useEffect(() => {
+    if (status === 'running' && containerRef.current) {
+      containerRef.current.focus();
+    }
+  }, [status]);
 
   // Navigate ke results saat finished
   useEffect(() => {

--- a/src/store/slices/inputSlice.ts
+++ b/src/store/slices/inputSlice.ts
@@ -40,30 +40,29 @@ export const createInputSlice: InputSliceCreator = (set, get) => ({
       lastKeystrokeTime: now,
     });
 
-    // Auto-complete untuk mode words: selesaikan jika ini huruf terakhir dari kata terakhir
-    if (state.testMode === 'words') {
-      const isLastWord = state.currentWordIndex === state.duration - 1;
-      const isWordComplete = newInput === currentWord;
+    // Auto-complete: selesaikan jika ini huruf terakhir dari kata terakhir
+    // Berlaku untuk semua mode (words, practice, dan time jika semua kata habis)
+    const isLastWord = state.currentWordIndex === state.words.length - 1;
+    const isWordComplete = newInput === currentWord;
 
-      if (isLastWord && isWordComplete) {
-        const typoCount = newKeystrokes.filter((k) => !k.correct).length;
-        const wordResult = {
-          expected: currentWord,
-          typed: newInput,
-          correct: true,
-          startTime: state.currentWordStartTime || now,
-          endTime: now,
-          keystrokes: newKeystrokes,
-          typoCount,
-          hand: getWordHand(currentWord),
-        };
+    if (isLastWord && isWordComplete && currentWord) {
+      const typoCount = newKeystrokes.filter((k) => !k.correct).length;
+      const wordResult = {
+        expected: currentWord,
+        typed: newInput,
+        correct: true,
+        startTime: state.currentWordStartTime || now,
+        endTime: now,
+        keystrokes: newKeystrokes,
+        typoCount,
+        hand: getWordHand(currentWord),
+      };
 
-        set({
-          wordResults: [...state.wordResults, wordResult],
-          currentWordIndex: state.currentWordIndex + 1,
-        });
-        get().finishTest();
-      }
+      set({
+        wordResults: [...state.wordResults, wordResult],
+        currentWordIndex: state.currentWordIndex + 1,
+      });
+      get().finishTest();
     }
   },
 

--- a/src/store/typingStore.ts
+++ b/src/store/typingStore.ts
@@ -46,10 +46,15 @@ export const useTypingStore = create<TypingState>()(
     {
       name: 'typing-test-storage',
       partialize: (state) => ({
-        problemWords: state.problemWords,
-        testHistory: state.testHistory,
+        // User preferences (persist across sessions)
+        testMode: state.testMode,
+        handMode: state.handMode,
+        duration: state.duration,
         soundEnabled: state.soundEnabled,
         soundVolume: state.soundVolume,
+        // User data
+        problemWords: state.problemWords,
+        testHistory: state.testHistory,
       }),
     }
   )


### PR DESCRIPTION
## Summary

Fixes #6

- **Auto-complete untuk semua mode**: Menggunakan `words.length` bukan `duration` untuk menentukan kata terakhir
- **Auto-focus saat masuk test**: User langsung bisa mengetik tanpa klik
- **Persist settings**: testMode, handMode, duration tersimpan di localStorage

## Perubahan Detail

### 1. Auto-complete (`src/store/slices/inputSlice.ts`)
```typescript
// Sebelum - hanya words mode
if (state.testMode === 'words' || state.isPractice) {
  const totalWords = state.isPractice ? state.words.length : state.duration;

// Sesudah - semua mode
const isLastWord = state.currentWordIndex === state.words.length - 1;
```

### 2. Auto-focus (`src/app/test/page.tsx`)
```typescript
useEffect(() => {
  if (status === 'running' && containerRef.current) {
    containerRef.current.focus();
  }
}, [status]);
```

### 3. Persist Settings (`src/store/typingStore.ts`)
- Tambah `testMode`, `handMode`, `duration` ke `partialize`

### 4. Tests (`src/__tests__/inputSlice.test.ts`)
- Update test auto-complete
- Tambah test practice mode

## Test Plan

- [ ] Mode Kata: ketik sampai kata terakhir, auto-complete tanpa spasi
- [ ] Mode Latihan: ketik sampai kata terakhir, auto-complete tanpa spasi
- [ ] Mode Waktu: ketik kata pertama, TIDAK auto-complete (karena bukan kata terakhir)
- [ ] Masuk `/test`: langsung bisa mengetik tanpa klik
- [ ] Pilih mode Kata, refresh halaman: mode tetap Kata
- [ ] `npm test` - 17 tests pass